### PR TITLE
Add delete endpoint Articles table

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/ArticlesController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/ArticlesController.java
@@ -88,4 +88,22 @@ public class ArticlesController extends ApiController {
 
         return savedArticle;
     }
+
+    /**
+     * Delete a Article
+     * 
+     * @param id the id of the article to delete
+     * @return a message indicating the article was deleted
+     */
+    @Operation(summary= "Delete a Article")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("")
+    public Object deleteArticle(
+            @Parameter(name="id") @RequestParam Long id) {
+        Article article = articleRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(Article.class, id));
+
+        articleRepository.delete(article);
+        return genericMessage("Article with id %s deleted".formatted(id));
+    }
 }

--- a/src/main/java/edu/ucsb/cs156/example/controllers/ArticlesController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/ArticlesController.java
@@ -1,87 +1,91 @@
-// package edu.ucsb.cs156.example.controllers;
+package edu.ucsb.cs156.example.controllers;
 
-// import edu.ucsb.cs156.example.entities.Article;
-// import edu.ucsb.cs156.example.entities.UCSBDate;
-// import edu.ucsb.cs156.example.errors.EntityNotFoundException;
-// import edu.ucsb.cs156.example.repositories.ArticleRepository;
-// import edu.ucsb.cs156.example.repositories.UCSBDateRepository;
-// import io.swagger.v3.oas.annotations.Operation;
-// import io.swagger.v3.oas.annotations.Parameter;
-// import io.swagger.v3.oas.annotations.tags.Tag;
-// import lombok.extern.slf4j.Slf4j;
+import edu.ucsb.cs156.example.entities.Article;
+import edu.ucsb.cs156.example.entities.UCSBDate;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
+import edu.ucsb.cs156.example.repositories.ArticleRepository;
+import edu.ucsb.cs156.example.repositories.UCSBDateRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
 
-// import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.JsonProcessingException;
 
-// import org.springframework.beans.factory.annotation.Autowired;
-// import org.springframework.format.annotation.DateTimeFormat;
-// import org.springframework.security.access.prepost.PreAuthorize;
-// import org.springframework.web.bind.annotation.DeleteMapping;
-// import org.springframework.web.bind.annotation.GetMapping;
-// import org.springframework.web.bind.annotation.PostMapping;
-// import org.springframework.web.bind.annotation.PutMapping;
-// import org.springframework.web.bind.annotation.RequestBody;
-// import org.springframework.web.bind.annotation.RequestMapping;
-// import org.springframework.web.bind.annotation.RequestParam;
-// import org.springframework.web.bind.annotation.RestController;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
-// import jakarta.validation.Valid;
+import jakarta.validation.Valid;
 
-// import java.time.LocalDateTime;
+import java.time.LocalDateTime;
 
-// @Tag(name = "Articles")
-// @RequestMapping("/api/articles")
-// @RestController
-// @Slf4j
-// public class ArticlesController {
+@Tag(name = "Articles")
+@RequestMapping("/api/articles")
+@RestController
+@Slf4j
+public class ArticlesController extends ApiController {
 
-//     @Autowired
-//     ArticleRepository articleRepository;
+    @Autowired
+    ArticleRepository articleRepository;
     
+    /**
+     * List all articles
+     * 
+     * @return an iterable of Article
+     */
+    @Operation(summary= "List all articles")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/all")
+    public Iterable<Article> allArticles() {
+        Iterable<Article> articles = articleRepository.findAll();
+        return articles;
+    }
 
-//     @Operation(summary= "List all ucsb dates")
-//     @PreAuthorize("hasRole('ROLE_USER')")
-//     @GetMapping("/all")
-//     public Iterable<Article> allUCSBDates() {
-//         Iterable<Article> articles1 = articleRepository.findAll();
-//         return articles1;
-//     }
 
+     /**
+     * Create a new article
+     * 
+     * @param title  the title of the article
+     * @param url     the url of the article 
+     * @param explanation the explanation of the article 
+     * @param email the email associated with the article 
+     * @param dateAdded the date 
+     * @return the saved article
+     */
+    @Operation(summary= "Create a new article")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/post")
+    public Article postArticle(
+            @Parameter(name="title") @RequestParam String title,
+            @Parameter(name="url") @RequestParam String url,
+            @Parameter(name="explanation") @RequestParam String explanation,
+            @Parameter(name="email") @RequestParam String email,
+            @Parameter(name="dateAdded", description="(in iso format, e.g. YYYY-mm-ddTHH:MM:SS; see https://en.wikipedia.org/wiki/ISO_8601)") @RequestParam("dateAdded") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime dateAdded)
+            throws JsonProcessingException {
 
-//      /**
-//      * Create a new article
-//      * 
-//      * @param title  the title of the article
-//      * @param url     the url of the article 
-//      * @param explanation the explanation of the article 
-//      * @param email the email associated with the article 
-//      * @param localDateTime the date 
-//      * @return the saved article
-//      */
-//     @Operation(summary= "Create a new article")
-//     @PreAuthorize("hasRole('ROLE_ADMIN')")
-//     @PostMapping("/post")
-//     public Article postArticle(
-//             @Parameter(name="title") @RequestParam String title,
-//             @Parameter(name="url") @RequestParam String url,
-//             @Parameter(name="explanation") @RequestParam String explanation,
-//             @Parameter(name="email") @RequestParam String email,
-//             @Parameter(name="date (in iso format, e.g. YYYY-mm-ddTHH:MM:SS; see https://en.wikipedia.org/wiki/ISO_8601)") @RequestParam("localDateTime") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime localDateTime)
-//             throws JsonProcessingException {
+        // For an explanation of @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+        // See: https://www.baeldung.com/spring-date-parameters
 
-//         // For an explanation of @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-//         // See: https://www.baeldung.com/spring-date-parameters
+        log.info("dateAdded={}", dateAdded);
 
-//         log.info("localDateTime={}", localDateTime);
+        Article article = new Article();
+        article.setTitle(title);
+        article.setUrl(url);
+        article.setExplanation(explanation);
+        article.setEmail(email);
+        article.setDateAdded(dateAdded);
 
-//         Article article = new Article();
-//         article.setTitle(title);
-//         article.setUrl(url);
-//         article.setExplanation(explanation);
-//         article.setEmail(email);
-//         article.setLocalDateTime(localDateTime);
+        Article savedArticle = articleRepository.save(article);
 
-//         Article savedArticle = articleRepository.save(article);
-
-//         return savedArticle;
-//     }
-// }
+        return savedArticle;
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/example/entities/Article.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/Article.java
@@ -14,7 +14,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-@Entity(name = "article")
+@Entity(name = "articles")
 public class Article {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -24,5 +24,5 @@ public class Article {
     private String url;
     private String explanation;
     private String email;
-    private LocalDateTime localDateTime;
+    private LocalDateTime dateAdded;
 }

--- a/src/main/resources/db/migration/changes/Articles.json
+++ b/src/main/resources/db/migration/changes/Articles.json
@@ -12,7 +12,7 @@
               "not": [
                 {
                   "tableExists": {
-                    "tableName": "articles"
+                    "tableName": "ARTICLES"
                   }
                 }
               ]
@@ -59,12 +59,12 @@
                   },
                   {
                     "column": {
-                      "name": "LOCAL_DATE_TIME",
+                      "name": "DATE_ADDED",
                       "type": "TIMESTAMP"
                     }
                   }
                 ],
-                "tableName": "articles"
+                "tableName": "ARTICLES"
               }
             }
           ]

--- a/src/test/java/edu/ucsb/cs156/example/controllers/ArticlesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/ArticlesControllerTests.java
@@ -3,7 +3,7 @@ package edu.ucsb.cs156.example.controllers;
 import edu.ucsb.cs156.example.repositories.UserRepository;
 import edu.ucsb.cs156.example.testconfig.TestConfig;
 import edu.ucsb.cs156.example.ControllerTestCase;
-import edu.ucsb.cs156.example.entities.Article;
+import edu.ucsb.cs156.example.entities.Article; 
 import edu.ucsb.cs156.example.entities.UCSBDate;
 import edu.ucsb.cs156.example.repositories.ArticleRepository;
 

--- a/src/test/java/edu/ucsb/cs156/example/controllers/ArticlesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/ArticlesControllerTests.java
@@ -1,0 +1,150 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.Article;
+import edu.ucsb.cs156.example.entities.UCSBDate;
+import edu.ucsb.cs156.example.repositories.ArticleRepository;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+import java.time.LocalDateTime;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@WebMvcTest(controllers = ArticlesController.class)
+@Import(TestConfig.class)
+public class ArticlesControllerTests extends ControllerTestCase{
+
+    @MockBean
+    ArticleRepository articleRepository;
+
+    @MockBean
+    UserRepository userRepository;
+
+    // Authorization tests for /api/articles/admin/all
+
+    @Test
+    public void logged_out_users_cannot_get_all() throws Exception {
+            mockMvc.perform(get("/api/articles/all"))
+                            .andExpect(status().is(403)); // logged out users can't get all
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_users_can_get_all() throws Exception {
+            mockMvc.perform(get("/api/articles/all"))
+                            .andExpect(status().is(200)); // logged
+    }
+
+
+    // Authorization tests for /api/articles/post
+        // (Perhaps should also have these for put and delete)
+
+    @Test
+    public void logged_out_users_cannot_post() throws Exception {
+            mockMvc.perform(post("/api/articles/post"))
+                            .andExpect(status().is(403));
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_regular_users_cannot_post() throws Exception {
+            mockMvc.perform(post("/api/articles/post"))
+                            .andExpect(status().is(403)); // only admins can post
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_user_can_get_all_ucsbdates() throws Exception {
+
+            // arrange
+            LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+            Article article1 = Article.builder()
+                            .email("ben@gmail.com")
+                            .dateAdded(ldt1)
+                            .url("https://google.com")
+                            .title("Ben")
+                            .explanation("benny")
+                            .build();
+
+            LocalDateTime ldt2 = LocalDateTime.parse("2022-03-11T00:00:00");
+
+            Article article2 = Article.builder()
+                            .email("josh@gmail.com")
+                            .dateAdded(ldt2)
+                            .url("https://google.com")
+                            .title("Josh")
+                            .explanation("jiddy")
+                            .build();
+
+            ArrayList<Article> expectedArticles = new ArrayList<>();
+            expectedArticles.addAll(Arrays.asList(article1, article2));
+
+            when(articleRepository.findAll()).thenReturn(expectedArticles);
+
+            // act
+            MvcResult response = mockMvc.perform(get("/api/articles/all"))
+                            .andExpect(status().isOk()).andReturn();
+
+            // assert
+
+            verify(articleRepository, times(1)).findAll();
+            String expectedJson = mapper.writeValueAsString(expectedArticles);
+            String responseString = response.getResponse().getContentAsString();
+            assertEquals(expectedJson, responseString);
+    }
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void an_admin_user_can_post_a_new_article() throws Exception {
+            // arrange
+
+            LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+            Article article1 = Article.builder()
+                            .email("ben@gmail.com")
+                            .dateAdded(ldt1)
+                            .url("https://google.com")
+                            .title("Ben")
+                            .explanation("thing")
+                            .build();
+
+            when(articleRepository.save(eq(article1))).thenReturn(article1);
+
+            // act
+            MvcResult response = mockMvc.perform(
+                            post("/api/articles/post?email=ben@gmail.com&url=https://google.com&dateAdded=2022-01-03T00:00:00&title=Ben&explanation=thing")
+                                            .with(csrf()))
+                            .andExpect(status().isOk()).andReturn();
+
+            // assert
+            verify(articleRepository, times(1)).save(article1);
+            String expectedJson = mapper.writeValueAsString(article1);
+            String responseString = response.getResponse().getContentAsString();
+            assertEquals(expectedJson, responseString);
+    }
+    
+}


### PR DESCRIPTION
Closes #42 

Added a delete endpoint for the Articles table 
- Functionality works well on both local host and the dokku deployment 
- Tests receive 100% mutation and line coverage